### PR TITLE
Fix bug when rowStartIdx is off after filtering

### DIFF
--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -7,10 +7,10 @@ const Table = ({ className, columns, rows, perPage }) => {
   const [displayedRows, setDisplayedRows] = useState(rows.slice(0, perPage));
 
   useEffect(() => {
-    if (rows.length < rowStartIdx) {
-      setRowStartIdx(0);
-    }
+    setRowStartIdx(0);
+  }, [rows]);
 
+  useEffect(() => {
     setDisplayedRows(rows.slice(rowStartIdx, rowStartIdx + perPage));
   }, [rowStartIdx, rows, perPage]);
 


### PR DESCRIPTION
Added another `useEffect` that depends on `rows` and sets `rowStartIdx` to 0.